### PR TITLE
exposes site-settings to normal users

### DIFF
--- a/e2e/adminSiteSettings.e2e-spec.ts
+++ b/e2e/adminSiteSettings.e2e-spec.ts
@@ -12,8 +12,8 @@ describe('AdminSiteSettings', () => {
     jest.spyOn(console, 'log').mockImplementation(jest.fn());
   });
 
-  describe('/GET /admin/users', () => {
-    it('returns the siteSettings', async () => {
+  describe('/GET /admin/site-settings', () => {
+    it('updates the siteSettings', async () => {
       const res = await makeRequest({
         method: 'PUT',
         url: '/admin/site-settings',

--- a/e2e/siteSettings.e2e-spec.ts
+++ b/e2e/siteSettings.e2e-spec.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { makeRequest, createUserToken } from './utils';
+
+describe('SiteSettings', () => {
+  let userToken: string;
+
+  beforeAll(async () => {
+    userToken = await createUserToken();
+    jest.spyOn(console, 'log').mockImplementation(jest.fn());
+  });
+
+  describe('/GET /site-settings', () => {
+    it('returns the siteSettings', async () => {
+      const res = await makeRequest({
+        method: 'GET',
+        url: '/site-settings',
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      const { data: result } = res;
+      expect(result).toBeDefined();
+      expect(result.data.site_name).toBeDefined();
+    });
+  });
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { ValidationPipe } from './utils/validationPipe';
 import { AuthModule } from './components/Auth/auth.module';
 import { AdminModule } from './components/AdminUser/adminUser.module';
 import { AdminSiteSettingsModule } from './components/AdminSiteSettings/adminSiteSettings.module';
+import { SiteSettingsModule } from './components/SiteSettings/siteSettings.module';
 import { TimeoutInterceptor, AuthInterceptor, LoggingInterceptor } from './interceptors';
 
 export const getMailTransport = (configService: ConfigService): object | string => {
@@ -61,6 +62,7 @@ export const getMailTransport = (configService: ConfigService): object | string 
     AuthModule,
     AdminModule,
     AdminSiteSettingsModule,
+    SiteSettingsModule,
   ],
   providers: [
     {

--- a/src/components/AdminSiteSettings/__tests__/adminSiteSettings.controller.spec.ts
+++ b/src/components/AdminSiteSettings/__tests__/adminSiteSettings.controller.spec.ts
@@ -3,13 +3,19 @@
 import { SiteSettingsRepositoryMock, mockSiteSettings } from '../../../mocks/index';
 import { AdminSiteSettingsController } from '../adminSiteSettings.controller';
 import { AdminSiteSettingsService } from '../adminSiteSettings.service';
+import { SiteSettingsService } from './../../SiteSettings/siteSettings.service';
 
 describe('AdminSiteSettingsController', () => {
   let adminSiteSettingsService: AdminSiteSettingsService;
   let adminSiteSettingsController: AdminSiteSettingsController;
+  let siteSettingsService: SiteSettingsService;
 
   beforeEach(() => {
-    adminSiteSettingsService = new AdminSiteSettingsService(SiteSettingsRepositoryMock);
+    siteSettingsService = new SiteSettingsService(SiteSettingsRepositoryMock);
+    adminSiteSettingsService = new AdminSiteSettingsService(
+      SiteSettingsRepositoryMock,
+      siteSettingsService,
+    );
     adminSiteSettingsController = new AdminSiteSettingsController(
       adminSiteSettingsService,
     );

--- a/src/components/AdminSiteSettings/__tests__/adminSiteSettings.service.spec.ts
+++ b/src/components/AdminSiteSettings/__tests__/adminSiteSettings.service.spec.ts
@@ -3,61 +3,18 @@
 import { SiteSettings } from './../../../Repositories/siteSettings.entity';
 import { SiteSettingsRepositoryMock, mockSiteSettings } from './../../../mocks/index';
 import { AdminSiteSettingsService } from './../../AdminSiteSettings/adminSiteSettings.service';
-import { DeepPartial } from 'typeorm';
+import { SiteSettingsService } from './../../SiteSettings/siteSettings.service';
 
 describe('AdminSiteSettingsService', () => {
   let adminSiteSettingsService: AdminSiteSettingsService;
+  let siteSettingsService: SiteSettingsService;
 
   beforeEach(() => {
-    adminSiteSettingsService = new AdminSiteSettingsService(SiteSettingsRepositoryMock);
-  });
-
-  describe('createSiteSettings', () => {
-    it('returns Promise<SiteSettingsDto>', async () => {
-      jest
-        .spyOn(SiteSettingsRepositoryMock, 'save')
-        .mockImplementationOnce(
-          () =>
-            (mockSiteSettings as unknown) as Promise<
-              DeepPartial<SiteSettings> & SiteSettings
-            >,
-        );
-      expect(await adminSiteSettingsService['createSiteSettings']()).toEqual(
-        await mockSiteSettings,
-      );
-    });
-  });
-
-  describe('getSiteSettings', () => {
-    it('returns Promise<SiteSettingsDto> 1', async () => {
-      jest
-        .spyOn(SiteSettingsRepositoryMock, 'find')
-        .mockImplementationOnce(
-          () => ([mockSiteSettings] as unknown) as Promise<SiteSettings[]>,
-        );
-
-      expect(await adminSiteSettingsService.getSiteSettings()).toEqual(
-        await mockSiteSettings,
-      );
-    });
-
-    it('returns Promise<SiteSettingsDto> 2', async () => {
-      jest
-        .spyOn(SiteSettingsRepositoryMock, 'find')
-        .mockImplementationOnce(() => ([] as unknown) as Promise<SiteSettings[]>);
-      jest
-        .spyOn(SiteSettingsRepositoryMock, 'save')
-        .mockImplementationOnce(
-          () =>
-            (mockSiteSettings as unknown) as Promise<
-              DeepPartial<SiteSettings> & SiteSettings
-            >,
-        );
-
-      expect(await adminSiteSettingsService.getSiteSettings()).toEqual(
-        await mockSiteSettings,
-      );
-    });
+    siteSettingsService = new SiteSettingsService(SiteSettingsRepositoryMock);
+    adminSiteSettingsService = new AdminSiteSettingsService(
+      SiteSettingsRepositoryMock,
+      siteSettingsService,
+    );
   });
 
   describe('updateSiteSettings', () => {

--- a/src/components/AdminSiteSettings/adminSiteSettings.module.ts
+++ b/src/components/AdminSiteSettings/adminSiteSettings.module.ts
@@ -4,9 +4,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SiteSettings } from '../../Repositories/siteSettings.entity';
 import { AdminSiteSettingsController } from './adminSiteSettings.controller';
 import { AdminSiteSettingsService } from './adminSiteSettings.service';
+import { SiteSettingsModule } from './../SiteSettings/siteSettings.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SiteSettings])],
+  imports: [TypeOrmModule.forFeature([SiteSettings]), SiteSettingsModule],
   providers: [AdminSiteSettingsService],
   controllers: [AdminSiteSettingsController],
 })

--- a/src/components/AdminSiteSettings/adminSiteSettings.service.ts
+++ b/src/components/AdminSiteSettings/adminSiteSettings.service.ts
@@ -6,33 +6,19 @@ import { Repository } from 'typeorm';
 
 import { SiteSettings } from '../../Repositories/siteSettings.entity';
 import { SiteSettingsDto, UpdateSiteSettingsDto } from './dto';
+import { SiteSettingsService } from './../SiteSettings/siteSettings.service';
 
 @Injectable()
 export class AdminSiteSettingsService {
   constructor(
     @InjectRepository(SiteSettings)
     private readonly siteSettingsRepository: Repository<SiteSettings>,
+    private readonly siteSettingsService: SiteSettingsService,
   ) {}
-
-  private async createSiteSettings(): Promise<SiteSettingsDto> {
-    return await this.siteSettingsRepository.save({
-      site_name: 'The Booking System',
-      maximum_event_attendees: 12,
-    });
-  }
-
-  async getSiteSettings(): Promise<SiteSettingsDto> {
-    let settings: SiteSettingsDto;
-    settings = (await this.siteSettingsRepository.find())[0];
-    if (!settings) {
-      return await this.createSiteSettings();
-    }
-    return settings;
-  }
 
   async updateSiteSettings(values: UpdateSiteSettingsDto): Promise<SiteSettingsDto> {
     let settings: SiteSettingsDto;
-    settings = await this.getSiteSettings();
+    settings = await this.siteSettingsService.getSiteSettings();
 
     const siteSettingsEntity = new SiteSettings();
     Object.assign(siteSettingsEntity, values);

--- a/src/components/SiteSettings/__tests__/siteSettings.controller.spec.ts
+++ b/src/components/SiteSettings/__tests__/siteSettings.controller.spec.ts
@@ -1,0 +1,25 @@
+import { SiteSettingsRepositoryMock, mockSiteSettings } from '../../../mocks/index';
+import { SiteSettingsService } from './../../SiteSettings/siteSettings.service';
+import { SiteSettingsController } from './../siteSettings.controller';
+
+describe('SiteSettingsController', () => {
+  let siteSettingsService: SiteSettingsService;
+  let siteSettingsController: SiteSettingsController;
+
+  beforeEach(() => {
+    siteSettingsService = new SiteSettingsService(SiteSettingsRepositoryMock);
+    siteSettingsController = new SiteSettingsController(siteSettingsService);
+  });
+
+  describe('/GET /site-settings', () => {
+    it('returns Promise<SiteSettingsDto>', async () => {
+      jest
+        .spyOn(siteSettingsService, 'getSiteSettings')
+        .mockImplementationOnce(() => mockSiteSettings);
+
+      expect(await siteSettingsController.getSiteSettings()).toEqual(
+        await mockSiteSettings,
+      );
+    });
+  });
+});

--- a/src/components/SiteSettings/__tests__/siteSettings.service.spec.ts
+++ b/src/components/SiteSettings/__tests__/siteSettings.service.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
+import { SiteSettings } from './../../../Repositories/siteSettings.entity';
+import { SiteSettingsRepositoryMock, mockSiteSettings } from '../../../mocks/index';
+import { SiteSettingsService } from './../../SiteSettings/siteSettings.service';
+import { DeepPartial } from 'typeorm';
+
+describe('SiteSettingsService', () => {
+  let siteSettingsService: SiteSettingsService;
+
+  beforeEach(() => {
+    siteSettingsService = new SiteSettingsService(SiteSettingsRepositoryMock);
+  });
+
+  describe('createSiteSettings', () => {
+    it('returns Promise<SiteSettingsDto>', async () => {
+      jest
+        .spyOn(SiteSettingsRepositoryMock, 'save')
+        .mockImplementationOnce(
+          () =>
+            (mockSiteSettings as unknown) as Promise<
+              DeepPartial<SiteSettings> & SiteSettings
+            >,
+        );
+      expect(await siteSettingsService['createSiteSettings']()).toEqual(
+        await mockSiteSettings,
+      );
+    });
+  });
+
+  describe('getSiteSettings', () => {
+    it('returns Promise<SiteSettingsDto> 1', async () => {
+      jest
+        .spyOn(SiteSettingsRepositoryMock, 'find')
+        .mockImplementationOnce(
+          () => ([mockSiteSettings] as unknown) as Promise<SiteSettings[]>,
+        );
+
+      expect(await siteSettingsService.getSiteSettings()).toEqual(await mockSiteSettings);
+    });
+
+    it('returns Promise<SiteSettingsDto> 2', async () => {
+      jest
+        .spyOn(SiteSettingsRepositoryMock, 'find')
+        .mockImplementationOnce(() => ([] as unknown) as Promise<SiteSettings[]>);
+      jest
+        .spyOn(SiteSettingsRepositoryMock, 'save')
+        .mockImplementationOnce(
+          () =>
+            (mockSiteSettings as unknown) as Promise<
+              DeepPartial<SiteSettings> & SiteSettings
+            >,
+        );
+
+      expect(await siteSettingsService.getSiteSettings()).toEqual(await mockSiteSettings);
+    });
+  });
+});

--- a/src/components/SiteSettings/siteSettings.controller.ts
+++ b/src/components/SiteSettings/siteSettings.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { SiteSettingsService } from './siteSettings.service';
+import { SiteSettingsDto } from './../AdminSiteSettings/dto';
+
+@Controller('site-settings')
+export class SiteSettingsController {
+  constructor(private service: SiteSettingsService) {}
+
+  @Get()
+  getSiteSettings(): Promise<SiteSettingsDto> {
+    return this.service.getSiteSettings();
+  }
+}

--- a/src/components/SiteSettings/siteSettings.module.ts
+++ b/src/components/SiteSettings/siteSettings.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { SiteSettings } from '../../Repositories/siteSettings.entity';
+import { SiteSettingsService } from './siteSettings.service';
+import { SiteSettingsController } from './siteSettings.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SiteSettings])],
+  providers: [SiteSettingsService],
+  controllers: [SiteSettingsController],
+  exports: [SiteSettingsService],
+})
+export class SiteSettingsModule {}

--- a/src/components/SiteSettings/siteSettings.service.ts
+++ b/src/components/SiteSettings/siteSettings.service.ts
@@ -1,0 +1,32 @@
+/* eslint @typescript-eslint/camelcase: 0 */
+
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { SiteSettings } from '../../Repositories/siteSettings.entity';
+import { SiteSettingsDto } from './../AdminSiteSettings/dto/site.settings.dto';
+
+@Injectable()
+export class SiteSettingsService {
+  constructor(
+    @InjectRepository(SiteSettings)
+    private readonly siteSettingsRepository: Repository<SiteSettings>,
+  ) {}
+
+  private async createSiteSettings(): Promise<SiteSettingsDto> {
+    return await this.siteSettingsRepository.save({
+      site_name: 'The Booking System',
+      maximum_event_attendees: 12,
+    });
+  }
+
+  async getSiteSettings(): Promise<SiteSettingsDto> {
+    let settings: SiteSettingsDto;
+    settings = (await this.siteSettingsRepository.find())[0];
+    if (!settings) {
+      return await this.createSiteSettings();
+    }
+    return settings;
+  }
+}


### PR DESCRIPTION
This PR adds the following:
- a new endpoint which can be used by normal users to GET the site settings.
- Unit tests
- e2e tests